### PR TITLE
Feature/version display and target name change

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,7 @@ ASOURCES = display.s keyboard.s irq.s vectors.s versions.s
 LSOURCES = $(wildcard libsrc/*.c)
 LASOURCES = $(wildcard libsrc/*.s)
 
-PROGRAM = loci_rom
+PROGRAM = locirom
 LIBRARY = loci.lib
 
 word-dot = $(word $2,$(subst ., ,$1))

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,9 @@ LIBRARY = loci.lib
 word-dot = $(word $2,$(subst ., ,$1))
 
 ifdef VERSION 
-VERDEFS = --asm-define VERMAJOR=$(call word-dot,$(VERSION),1) --asm-define VERMINOR=$(call word-dot,$(VERSION),2) --asm-define VERPATCH=$(call word-dot,$(VERSION),3)
+export VERSION
+CFLAGS = -D VERSION
+VERDEFS = --asm-define VERSION --asm-define VERMAJOR=$(call word-dot,$(VERSION),1) --asm-define VERMINOR=$(call word-dot,$(VERSION),2) --asm-define VERPATCH=$(call word-dot,$(VERSION),3)
 else
 VERDEFS = --asm-define VERMAJOR=0 --asm-define VERMINOR=0 --asm-define VERPATCH=0
 endif
@@ -31,7 +33,7 @@ CC      = cl65
 AR      = ar65
 endif
 
-CFLAGS  =  -t $(CC65_TARGET) -O --debug-info -I ./include --asm-include-dir ./asminc -I ./asminc
+CFLAGS  +=  -t $(CC65_TARGET) -O --debug-info -I ./include --asm-include-dir ./asminc -I ./asminc
 LDFLAGS =  -C cfg/loci.cfg --debug-info -m $(PROGRAM).map
 CP      = cp -f
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,13 +6,22 @@ export CC65_HOME = /usr/share/cc65
 endif
 
 SOURCES = main.c tui.c
-ASOURCES = display.s keyboard.s irq.s vectors.s
+ASOURCES = display.s keyboard.s irq.s vectors.s versions.s
 
 LSOURCES = $(wildcard libsrc/*.c)
 LASOURCES = $(wildcard libsrc/*.s)
 
 PROGRAM = loci_rom
 LIBRARY = loci.lib
+
+word-dot = $(word $2,$(subst ., ,$1))
+
+ifdef VERSION 
+VERDEFS = --asm-define VERMAJOR=$(call word-dot,$(VERSION),1) --asm-define VERMINOR=$(call word-dot,$(VERSION),2) --asm-define VERPATCH=$(call word-dot,$(VERSION),3)
+else
+VERDEFS = --asm-define VERMAJOR=0 --asm-define VERMINOR=0 --asm-define VERPATCH=0
+endif
+
 
 ifneq ($(wildcard $(CC65_HOME)/bin/.*),)
 CC      = $(CC65_HOME)/bin/cl65
@@ -38,9 +47,9 @@ all: $(PROGRAM).rp6502
 
 %.o: %.s
 ifneq ($(strip $(CHECK_CC65)),)
-	$(CC) -c $(CFLAGS) --asm-define OLD_CC65 -o $@ $<
+	$(CC) -c $(CFLAGS) $(VERDEFS) --asm-define OLD_CC65 -o $@ $<
 else
-	$(CC) -c $(CFLAGS)  -o $@ $<
+	$(CC) -c $(CFLAGS) $(VERDEFS) -o $@ $<
 endif
 
 $(LIBRARY): $(LSOURCES:.c=.o) $(LASOURCES:.s=.o)

--- a/src/cfg/loci.cfg
+++ b/src/cfg/loci.cfg
@@ -23,6 +23,7 @@ SEGMENTS {
     FONTSTD:  load = ROM,    type = rw,  define   = yes,   run = TXCHRSTD;
     FONTALT:  load = ROM,    type = rw,  define   = yes,   run = TXCHRALT, optional = yes;
     SCREEN:   load = ROM,    type = rw,  define   = yes,   run = TXSCREEN, optional = yes;
+    VERSIONS: load = ROM,    type = ro,  start    = $FFF4;
     VECTORS:  load = ROM,    type = ro,  start    = $FFFA;
 }
 FEATURES {

--- a/src/include/loci.h
+++ b/src/include/loci.h
@@ -280,4 +280,7 @@ typedef enum
     LFS_ERR_NAMETOOLONG = 128 + 36   // File name too long
 } LFS_RESULT;
 
+extern unsigned char locirom_version[3];
+extern unsigned char locifw_version[3];
+
 #endif /* _LOCI_H */

--- a/src/main.c
+++ b/src/main.c
@@ -8,7 +8,7 @@
 #include "libsrc/dir.h"
 #include "libsrc/dirent.h"
 
-const char txt_title[] = "Loci ROM " __DATE__;
+char txt_title[40];
 const char txt_menu[] = "Select";
 const char txt_mdisc[] = "Microdisc";
 const char txt_df0[] = "  A:";
@@ -554,6 +554,14 @@ unsigned char Mouse(unsigned char key){
 
 void main(void){
     init_display();
+    #ifdef VERSION
+    sprintf(txt_title,"LOCI ROM %d.%d.%d FW %d.%d.%d",
+        locirom_version[2],locirom_version[1],locirom_version[0],
+        locifw_version[2], locifw_version[1], locifw_version[0]);
+    #else
+    sprintf(txt_title,"LOCI " __DATE__ " FW %d.%d.%d",
+        locifw_version[2], locifw_version[1], locifw_version[0]);
+    #endif
     tui_cls(3);
     sprintf(txt_rv1,"%02d",rv1);
     tui_draw(ui);

--- a/src/versions.s
+++ b/src/versions.s
@@ -1,0 +1,14 @@
+; ---------------------------------------------------------------------------
+; versions.s
+; ---------------------------------------------------------------------------
+;
+; Inserts the ROM version number in the file and makes space for the firmware's 
+
+.segment  "VERSIONS"
+
+.byte   VERPATCH
+.byte   VERMINOR
+.byte   VERMAJOR
+.byte   $F0
+.byte   $F1
+.byte   $F2    

--- a/src/versions.s
+++ b/src/versions.s
@@ -4,11 +4,15 @@
 ;
 ; Inserts the ROM version number in the file and makes space for the firmware's 
 
-.segment  "VERSIONS"
+.export _locirom_version 
+.export _locifw_version
 
+.segment  "VERSIONS"
+_locirom_version:
 .byte   VERPATCH
 .byte   VERMINOR
 .byte   VERMAJOR
+_locifw_version:
 .byte   $F0
 .byte   $F1
 .byte   $F2    


### PR DESCRIPTION
1. Integrates fixed location version numbers in the ROM binary for runtime identification of ROM and FW release versions. Version is set by setting VERSION environment variable for release builds only.
2. Adds display of version information in title row. Date is used for ROM dev builds, 0.0.0 for FW dev builds
3. Target name changed to locirom 