### PR TITLE
Feature/filter

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@ $(warning CC65_HOME not set. Defaulting to /usr/share/cc65)
 export CC65_HOME = /usr/share/cc65
 endif
 
-SOURCES = main.c tui.c
+SOURCES = main.c tui.c strisquint.c
 ASOURCES = display.s keyboard.s irq.s vectors.s versions.s
 
 LSOURCES = $(wildcard libsrc/*.c)

--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include "libsrc/dir.h"
 #include "libsrc/dirent.h"
+#include "strisquint.h"
 
 char txt_title[40];
 const char txt_menu[] = "Select";
@@ -36,6 +37,8 @@ const char txt_boot[] = "\x13\004Boot  ";
 const char txt_spinner[] = "/-\\|";
 const char txt_map[] = "RV1 adjust";
 char txt_rv1[4] = "--";
+char filter[8] = ".dsk";
+
 uint8_t rv1 = 99;
 uint8_t spin_cnt;
 
@@ -187,6 +190,12 @@ uint8_t dir_fill(char* dname){
         }else if(fil->d_attrib & DIR_ATTR_SYS){
             dir_buf[tail++] = '[';
         }else{
+            if(filter[0]){
+                if(!strisquint(fil->d_name, filter)){
+                    dir_entries--;  //roll-back
+                    continue;       //next file
+                }
+            }
             dir_buf[tail++] = ' ';
         }
         len = strlen(fil->d_name);
@@ -349,6 +358,10 @@ void DisplayKey(unsigned char key)
                     case(IDX_TAP):
                         calling_widget = tui_get_current();
                         tui_toggle_highlight(calling_widget);
+                        if(calling_widget <= IDX_DF3)
+                            strcpy(filter,".dsk");
+                        else
+                            strcpy(filter,".tap");
                         dir_ok = dir_fill(path);
                         parse_files_to_widget();
                         tui_draw(popup);
@@ -468,7 +481,12 @@ void DisplayKey(unsigned char key)
             break;
         case(KEY_RETURN):
             screen[y++] = 0x00;
-            dir_fill(screen);
+            //dir_fill(screen);
+            if(strisquint(screen,filter)){
+                DBG_STATUS("HIT ");
+            }else{
+                DBG_STATUS("MISS");
+            }
             //write(STDOUT_FILENO, screen, y);
             //write(STDOUT_FILENO, '\n', 1);
             //read(STDIN_FILENO, oscreen, 280);

--- a/src/main.c
+++ b/src/main.c
@@ -36,8 +36,9 @@ const char txt_dir_warning[] = "Max files. Use filter";
 const char txt_boot[] = "\x13\004Boot  ";
 const char txt_spinner[] = "/-\\|";
 const char txt_map[] = "RV1 adjust";
+const char txt_filter[] = "[      ]";
 char txt_rv1[4] = "--";
-char filter[8] = ".dsk";
+char filter[6] = ".dsk";
 
 uint8_t rv1 = 99;
 uint8_t spin_cnt;
@@ -110,21 +111,22 @@ tui_widget ui[] = {
 #define IDX_MAP_FFW 22
 #define IDX_BOOT 38
 
-#define POPUP_FILE_START 7
-tui_widget popup[32] = {
+#define POPUP_FILE_START 8
+tui_widget popup[POPUP_FILE_START+DIR_PAGE_SIZE+1] = {
     { TUI_START, 2, 2, 0, 0 },
     { TUI_BOX,  35,26, 0, 0 },
-    { TUI_TXT,   1, 0,30, path},
+    { TUI_TXT,   1, 0,22, path},
+    { TUI_TXT,  23, 0, 8, txt_filter},
+    { TUI_INP,  24, 0, 6, filter},
     { TUI_SEL,  31, 0, 3, txt_x},
-    { TUI_INP,   1,25, 8, filter},
     { TUI_TXT,  30,25, 1, dir_lpage},
     { TUI_TXT,  31,25, 1, dir_rpage},
     { TUI_END,   0, 0, 0, 0 }
 };
-#define IDX_XPAGE 3
 #define IDX_FILTER 4
-#define IDX_LPAGE 5
-#define IDX_RPAGE 6
+#define IDX_XPAGE 5
+#define IDX_LPAGE 6
+#define IDX_RPAGE 7
 
 tui_widget warning[] = {
     { TUI_START, 4,10, 0, 0},
@@ -297,6 +299,7 @@ void DisplayKey(unsigned char key)
                 if(len){
                     tmp_ptr[len-1] = '\0';
                     tui_draw_widget(idx);
+                    tui_toggle_highlight(idx);
                 }
             }else{
                 screen[0 + --y] = ' ';

--- a/src/main.c
+++ b/src/main.c
@@ -616,9 +616,9 @@ unsigned char Mouse(unsigned char key){
         cursor = 1;
         screen[pos] ^= 0x80;
         prev_pos = pos;
+        prev_x = x;
+        prev_y = y;
     }
-    prev_x = x;
-    prev_y = y;
     
     if(((btn ^ prev_btn) & btn & 0x01)){  //Left mouse button release
         widget = tui_hit(sx,sy);

--- a/src/strisquint.c
+++ b/src/strisquint.c
@@ -1,0 +1,30 @@
+#include <stdbool.h>
+
+//Non-exact case-insensitive substring search
+//Ignores bit 6 (0x20) when comparing characters
+
+bool strisquint(char *haystack, char *needle){
+    unsigned char i=0;
+    unsigned char j=0;
+    unsigned char mark=0;
+
+    if( needle[0] == '\0')
+        return true;
+
+    for(; haystack[i] != '\0'; i++ ){
+        if( (( haystack[i] ^ needle[j] ) & 0xdf ) == 0x00 ) //hit
+        {
+            if(j==0)                    //first hit?
+                mark = i;               //mark start in haystack
+            if( needle[++j] == '\0')    //end of needle after this?
+                return true;            //return match
+            continue;                   //check next pair
+        }
+        //miss
+        if(j){          //partial match before miss?
+            i = mark;   //return haystack to mark (+1 w/loop inc)
+            j = 0;      //retrun needle to start
+        }
+    }
+    return false;
+}

--- a/src/strisquint.h
+++ b/src/strisquint.h
@@ -1,0 +1,4 @@
+#include <stdbool.h>
+//Non-exact case-insensitive substring seach.
+//Gives false positives
+bool strisquint(char *haystack, char *needle);

--- a/src/tui.c
+++ b/src/tui.c
@@ -1,4 +1,5 @@
 #include "tui.h"
+#include <string.h>
 
 
 static tui_widget *tui_org_list;
@@ -17,6 +18,7 @@ void tui_draw(tui_widget* list){
             case TUI_INV:
             case TUI_SEL:
             case TUI_BTN:
+            case TUI_INP:
                 tui_draw_widget(i);
                 break;
             case TUI_END:
@@ -41,6 +43,9 @@ void tui_draw_widget(uint8_t widget_idx){
         case TUI_BTN:
             tui_draw_txt(list[widget_idx].x, list[widget_idx].y, (char *)list[widget_idx].data, list[widget_idx].len);
             tui_toggle_highlight(widget_idx);
+        case TUI_INP:
+            tui_clear_txt(widget_idx);
+            tui_draw_txt(list[widget_idx].x, list[widget_idx].y, (char *)list[widget_idx].data, list[widget_idx].len);
             break;
     }
 }
@@ -129,8 +134,18 @@ void tui_toggle_highlight(uint8_t widget_idx){
     unsigned char i;
     if(widget->type < TUI_ACTIVE) return; //Ignore passive widgets
     scr_widget = TUI_SCREEN_XY(tui_org_list->x + widget->x, tui_org_list->y + widget->y);
-    for(i=0;i<widget->len;i++){
-        scr_widget[i] ^= 0x80;  //Toggle invert bit
+    if(widget->type == TUI_INP){
+        scr_widget += strlen(widget->data);
+        if(scr_widget[0] == ' '){
+            scr_widget[0] ^= 0x80;
+        }
+        else{
+            scr_widget[0] = ' ';
+        } 
+    }else{
+        for(i=0;i<widget->len;i++){
+            scr_widget[i] ^= 0x80;  //Toggle invert bit
+        }
     }
 }
 
@@ -149,6 +164,12 @@ void tui_set_data(uint8_t widget_idx, const char* data){
 }
 const char* tui_get_data(uint8_t widget_idx){
     return tui_org_list[widget_idx].data;
+}
+enum tui_type tui_get_type(uint8_t widget_idx){
+    return tui_org_list[widget_idx].type;
+}
+unsigned char tui_get_len(uint8_t widget_idx){
+    return tui_org_list[widget_idx].len;
 }
 
 void tui_next_active(void){

--- a/src/tui.h
+++ b/src/tui.h
@@ -29,7 +29,8 @@ enum tui_type {
     TUI_INV,
     //Active widgets
     TUI_SEL = TUI_ACTIVE,       //TXT but selectable
-    TUI_BTN             //SEL but reversed paper/ink
+    TUI_BTN,                    //SEL but reversed paper/ink
+    TUI_INP,                    //INPut field
 };
 
 struct _tui_widget {
@@ -50,6 +51,8 @@ void tui_set_current(uint8_t widget_idx);
 uint8_t tui_get_current(void);
 void tui_set_data(uint8_t widget_idx, const char* data);
 const char* tui_get_data(uint8_t widget_idx);
+enum tui_type tui_get_type(uint8_t widget_idx);
+unsigned char tui_get_len(uint8_t widget_idx);
 
 void tui_draw_clr(uint8_t w, uint8_t h);
 void tui_draw_box(unsigned char w, unsigned char h);


### PR DESCRIPTION
Adding basic filtering functionality for directory listings. Defaults to ".dsk" for FDC and ".tap" for cassette. Known issue: current keyboard routine does not allow use of shifted characters. Some filters are thus not possible to write until the keyboard routine is updated.