### PR TITLE
Feature/timing adjust

### DIFF
--- a/src/include/loci.h
+++ b/src/include/loci.h
@@ -86,6 +86,7 @@ void __fastcall__ mia_set_ax (unsigned int ax);
 
 int __fastcall__ mia_call_int (unsigned char op);
 long __fastcall__ mia_call_long (unsigned char op);
+void __fastcall__ mia_call_void (unsigned char op);
 
 /* These run _mappederrno() on error */
 
@@ -128,6 +129,7 @@ long __fastcall__ mia_call_long_errno (unsigned char op);
 #define MIA_OP_TUNE_TIOW 0xA3
 #define MIA_OP_TUNE_TIOD 0xA4
 #define MIA_OP_TUNE_TADR 0xA5
+#define MIA_OP_TUNE_SCAN 0xA6
 
 /* C API for the operating system. */
 
@@ -149,6 +151,7 @@ int __fastcall__ tune_tior (unsigned char delay);
 int __fastcall__ tune_tiow (unsigned char delay);
 int __fastcall__ tune_tiod (unsigned char delay);
 int __fastcall__ tune_tadr (unsigned char delay);
+void __fastcall__ tune_scan_enable (void);
 
 /* XREG location helpers */
 

--- a/src/libsrc/mia.s
+++ b/src/libsrc/mia.s
@@ -11,6 +11,7 @@
 .export _mia_set_axsreg, _mia_set_ax
 .export _mia_call_int, _mia_call_long
 .export _mia_call_int_errno, _mia_call_long_errno
+.export _mia_call_void
 
 .importzp sp, sreg
 .import incsp1
@@ -83,6 +84,11 @@ _mia_call_int_errno:
 _mia_call_long_errno:
     jsr _mia_call_long
     bmi ERROR
+    rts
+
+; void __fastcall__ mia_call_void(unsigned char op);
+_mia_call_void:
+    sta MIA_OP
     rts
 
 ERROR:

--- a/src/libsrc/tune.c
+++ b/src/libsrc/tune.c
@@ -26,3 +26,8 @@ int __fastcall__ tune_tadr (unsigned char delay)
     mia_set_ax (delay);
     return mia_call_int_errno (MIA_OP_TUNE_TADR);
 }
+
+void __fastcall__ tune_scan_enable (void)
+{
+    mia_call_void(MIA_OP_TUNE_SCAN);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -67,6 +67,9 @@ char path[PATH_SIZE];
 
 char drv_names[5][32];
 
+uint8_t auto_tune_tior(void);
+
+
 tui_widget ui[] = {
     { TUI_START, 1, 0, 0, 0 },
     //{ TUI_BOX,  39,28, 0, 0 },
@@ -612,6 +615,9 @@ void DisplayKey(unsigned char key)
                         case('r'):
                             tui_set_current(IDX_MAP_REW);
                             break;
+                        case('s'):
+                            auto_tune_tior();
+                            break;
                     }
                 }else{  
                     //Directory popup keyboard shortcuts
@@ -681,6 +687,24 @@ unsigned char Mouse(unsigned char key){
     } 
     prev_btn = btn;
     return key;
+}
+
+uint8_t auto_tune_tior(void){
+    uint8_t i, ch;
+    tune_scan_enable();
+    for(i=0; i<32; i++)
+        TUI_PUTC(2+i,25,18);
+    TUI_PUTC(2+32,25,16);
+    while(!(loci_tior & 0x80)){}    //Wait for scan to begin
+    while(!!(loci_tior & 0x80)){    //Scanning in progress
+        i = loci_tior & 0x7F;      //Using tior value as test pattern and map index
+        mia_push_char(i);
+        mia_push_char('A');
+        ch = mia_pop_char();        //Assignment needed to force read
+        if(mia_pop_char() != i)
+            TUI_PUTC(2+i,25,17);
+    }
+    return ch;
 }
 
 void main(void){


### PR DESCRIPTION
Initual timing scan functionality - preview.
Use 's' keyboard shortcut to run timing scan on tior. Displayed as a bad=red good=green line of spaces from 0 to 31 tior.
Requries scan function support in firmware.