### PR TITLE
Experiment/keyboard fix

### DIFF
--- a/src/irq.s
+++ b/src/irq.s
@@ -36,8 +36,6 @@ doneirq:
 
 _irq_int:
 
-_nmi_int:
-
 handler:
     cld
     sei
@@ -62,6 +60,34 @@ handler:
     tay
     pla
     tax
+    pla
+    cli
+    rti
+
+_nmi_int:
+    sei
+    pha
+    ; Write Status Register Number to PortA 
+    lda #$07 
+    sta VIA_PA2 
+
+    ; Tell AY this is Register Number 
+    lda #$FF 
+    sta VIA_PCR 
+
+    ; Clear CB2, as keeping it high hangs on some orics.
+    ; Pitty, as all this code could be run only once, otherwise
+    lda #$dd 
+    sta VIA_PCR 
+
+    lda #$40    ;Enable port output on 8912 
+
+    sta VIA_PA2 
+    lda #$fd 
+
+    sta VIA_PCR 
+    lda #$dd
+    sta VIA_PCR
     pla
     cli
     rti

--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -9,6 +9,8 @@
 // Initialization of ISR
 //extern void InitIRQ();
 
+extern void InitKeyboard();
+
 // Virtual keyboard matrix organized as follows:                     
 // - byte is row number (selected through AY)  
 // - bit in byte indicates the row (selected through the VIA port B) numbered 76543210 

--- a/src/keyboard.s
+++ b/src/keyboard.s
@@ -111,11 +111,15 @@ _KeyAsciiLower:
 
     ; Tell AY this is Register Number 
     lda #$FF 
+    nop
+    nop
     sta VIA_PCR
 
     ; Clear CB2, as keeping it high hangs on some orics.
     ; Pitty, as all this code could be run only once, otherwise
-    ldy #$dd 
+    ldy #$dd
+    nop
+    nop 
     sty VIA_PCR 
 
     ldx #7 
@@ -128,8 +132,12 @@ loop_row:   ;Clear relevant bank
 
     sta VIA_PA2 
     lda #$fd 
+    nop
+    nop
     sta VIA_PCR 
     lda #$dd
+    nop
+    nop
     sta VIA_PCR
 
 
@@ -161,8 +169,12 @@ loop_column:
 
     sta VIA_PA2 
     lda #$fd 
+    nop
+    nop
     sta VIA_PCR
     lda #$dd
+    nop
+    nop
     sta VIA_PCR
 
     lda VIA_PB 

--- a/src/keyboard.s
+++ b/src/keyboard.s
@@ -3,6 +3,7 @@
 
 .importzp sp, sreg
 
+.export _InitKeyboard
 .export _KeyMatrix, _KeyRowArrows, _KeyAsciiUpper, _KeyAsciiLower, _KeyCapsLock, _ReadKey, _ReadKeyNoBounce
 .export ReadKeyboard
 
@@ -101,7 +102,32 @@ _KeyAsciiLower:
 
 .code 
 
+.proc _InitKeyboard
+    pha
+    ; Write Status Register Number to PortA 
+    lda #$07 
+    sta VIA_PA2 
 
+    ; Tell AY this is Register Number 
+    lda #$FF 
+    sta VIA_PCR 
+
+    ; Clear CB2, as keeping it high hangs on some orics.
+    ; Pitty, as all this code could be run only once, otherwise
+    lda #$dd 
+    sta VIA_PCR 
+
+    lda #$40    ;Enable port output on 8912 
+
+    sta VIA_PA2 
+    lda #$fd 
+    sta VIA_PCR 
+    lda #$dd
+    sta VIA_PCR
+
+    pla
+    rts
+.endproc
 
 .proc ReadKeyboard
 

--- a/src/libsrc/crt0.s
+++ b/src/libsrc/crt0.s
@@ -69,19 +69,27 @@ _init:
 
     ; Tell AY this is Register Number 
     lda #$FF 
+    nop
+    nop
     sta VIA_PCR 
 
     ; Clear CB2, as keeping it high hangs on some orics.
     ; Pitty, as all this code could be run only once, otherwise
     ldy #$dd 
+    nop
+    nop
     sty VIA_PCR 
 
     lda #$40    ;Enable port output on 8912 
 
     sta VIA_PA2 
     lda #$fd 
+    nop
+    nop
     sta VIA_PCR 
     lda #$dd
+    nop
+    nop
     sta VIA_PCR
 
     cli

--- a/src/libsrc/crt0.s
+++ b/src/libsrc/crt0.s
@@ -63,35 +63,6 @@ _init:
     sta VIA_T1LH
     sta VIA_T1CH
 
-    ; Write Status Register Number to PortA 
-    lda #$07 
-    sta VIA_PA2 
-
-    ; Tell AY this is Register Number 
-    lda #$FF 
-    nop
-    nop
-    sta VIA_PCR 
-
-    ; Clear CB2, as keeping it high hangs on some orics.
-    ; Pitty, as all this code could be run only once, otherwise
-    ldy #$dd 
-    nop
-    nop
-    sty VIA_PCR 
-
-    lda #$40    ;Enable port output on 8912 
-
-    sta VIA_PA2 
-    lda #$fd 
-    nop
-    nop
-    sta VIA_PCR 
-    lda #$dd
-    nop
-    nop
-    sta VIA_PCR
-
     cli
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -1064,6 +1064,9 @@ void main(void){
     //parse_files_to_widget();
     //tui_draw(popup);
     //tui_draw_box(10,28);
+    
+    InitKeyboard();
+
     while(1){
         char kb;
         unsigned char key = ReadKeyNoBounce();


### PR DESCRIPTION
Fix for keyboard routine not working on Oric-1 machines that have had Service bulletine mod adding a high-pass filter to the VIA CB2 to AY BDIR connection. 

Real reason is not yet understood, but if the AY GPIO port that is used for the Oric keyboard matrix, is initialised too early it fails. The fix is basically to move the initialisation to as late as possible.